### PR TITLE
Add HL7 message comparison (field-level diff)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,8 @@ HL7 v2.x message toolkit: web viewer, terminal TUI, Python parsing library, and 
 Single self-contained HTML/CSS/JS file. Open directly in Firefox (`file://` works, no server needed).
 
 **Features:**
-- Three-panel layout: Input (paste/drag-drop/Open button) | Parsed table | Field detail
+- Three-panel layout: Input (paste/drag-drop/Open button) | Parsed table | Field detail | Compare (field-level diff)
+- **Compare tab**: paste/open a second message, get a field-by-field diff with summary bar, filter toggle, and side-by-side component breakdown in detail panel
 - Embedded HL7 v2.3 and v2.5 segment/field definitions (~23 segments each) with data type component breakdowns (~30 composite types)
 - Auto-detects HL7 version from MSH-12 (v2.3.1 maps to v2.3 definitions)
 - Correct MSH field numbering: MSH-1 = `|` (field separator), MSH-2 = encoding characters
@@ -44,13 +45,14 @@ venv/bin/pip install -r requirements-mcp.txt
 
 **Run:** Registered in `~/.claude.json` under `mcpServers.hl7` — starts automatically with Claude Code.
 
-**Tools (7):**
+**Tools (8):**
 - `hl7_parse` — Parse raw HL7 into structured JSON with definitions and profile overlays
 - `hl7_get_field` — Extract a specific field by address (e.g. "PID-5", "MSH-9.1")
 - `hl7_validate` — Check message for structural issues (missing required fields, length violations, unknown segments); with a profile: enforces `required` fields and `valueMap` value checks
 - `hl7_anonymize` — Strip PHI from PID/NK1 segments
 - `hl7_transform` — Modify field values by address (e.g. `{"PID-5": "DOE^JOHN"}`)
 - `hl7_send` — Send message via MLLP with optional TLS/mTLS
+- `hl7_diff` — Compare two messages field-by-field, returns structured JSON diff with per-field status and values
 - `hl7_explain` — Look up HL7 definitions (segments, fields, data types) without a message
 
 **Resources (3):**
@@ -71,7 +73,7 @@ venv/bin/pip install -r requirements-mcp.txt
 venv/bin/pytest tests/ -v
 ```
 
-42 tests covering core modules (parser, encoding, profile, anonymize, definitions). Uses all 3 sample messages as fixtures. No browser/UI tests — the Python core logic mirrors the web viewer's JS implementation, so these tests serve as a shared specification.
+63 tests covering core modules (parser, encoding, profile, anonymize, definitions, diff). Uses all 3 sample messages as fixtures. No browser/UI tests — the Python core logic mirrors the web viewer's JS implementation, so these tests serve as a shared specification.
 
 - `pytest.ini` sets `pythonpath = .` so no install step needed
 - `tests/conftest.py` — shared fixtures (parsed messages, sample profile)

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Switch between Input/Parsed/Raw using the tabs above the left panel.
 - **Anonymization** — toggle PID field anonymization with ASCII or Estonian (non-ASCII) name pools
 - **Live search** — filter fields by address, name, type, or value
 - **Click-to-highlight** — click a parsed row to highlight the corresponding position in raw view
+- **Message comparison** — Compare tab for field-level diff of two messages with summary bar, filter toggle (differences only / all), and side-by-side component breakdown in detail panel
 - **Keyboard navigation** — arrow keys, Enter to expand, Esc to clear search
 
 ### Keyboard Shortcuts (Web)
@@ -147,6 +148,12 @@ python3 -m hl7view file1.hl7 file2.hl7
 
 # Disable colors (for piping)
 python3 -m hl7view --no-color message.hl7
+
+# Compare two messages (field-level diff)
+python3 -m hl7view file1.hl7 file2.hl7 --diff
+
+# Include identical fields in diff output
+python3 -m hl7view file1.hl7 file2.hl7 --diff -e
 ```
 
 ### Anonymization
@@ -250,6 +257,7 @@ Add to `~/.claude.json` under `mcpServers`:
 | `hl7_anonymize` | Strip PHI from PID/NK1 segments with random replacements |
 | `hl7_transform` | Modify field values by address (e.g. `{"PID-5": "DOE^JOHN"}`) |
 | `hl7_send` | Send message via MLLP with optional TLS/mTLS, return ACK |
+| `hl7_diff` | Compare two messages field-by-field, return structured JSON diff |
 | `hl7_explain` | Look up HL7 definitions (segments, fields, data types) without a message |
 
 ### Resources

--- a/hl7-viewer.html
+++ b/hl7-viewer.html
@@ -246,6 +246,10 @@ border-bottom:1px solid var(--surface)}
 #diffTable tr.diff-a-only{background:rgba(243,139,168,0.06);border-left:3px solid var(--red)}
 #diffTable tr.diff-b-only{background:rgba(166,227,161,0.06);border-left:3px solid var(--green)}
 #diffTable tr.diff-identical{opacity:0.5}
+.diff-hl{background:rgba(250,179,135,0.3);border-radius:2px;padding:0 1px}
+.diff-hl-ins{background:rgba(166,227,161,0.25);border-radius:2px;padding:0 1px}
+.diff-hl-del{background:rgba(243,139,168,0.25);border-radius:2px;padding:0 1px;text-decoration:line-through;text-decoration-color:rgba(243,139,168,0.5)}
+.comp-table .diff-hl,.comp-table .diff-hl-ins,.comp-table .diff-hl-del{padding:1px 2px}
 #diffTable .addr{color:var(--blue);font-weight:500}
 #diffTable .fname{color:var(--green)}
 #diffTable .fval{color:var(--text);font-family:inherit}
@@ -2642,6 +2646,73 @@ function rerenderDiffTable() {
   if (diffResult) renderDiffTable();
 }
 
+/** Find the differing middle portion between two strings.
+ *  Returns {prefix, midA, midB, suffixA, suffixB} or null if identical. */
+function charDiff(a, b) {
+  if (a === b) return null;
+  let p = 0;
+  const minLen = Math.min(a.length, b.length);
+  while (p < minLen && a[p] === b[p]) p++;
+  let sa = a.length, sb = b.length;
+  while (sa > p && sb > p && a[sa - 1] === b[sb - 1]) { sa--; sb--; }
+  return { prefix: a.substring(0, p), midA: a.substring(p, sa), midB: b.substring(p, sb),
+    suffixA: a.substring(sa), suffixB: b.substring(sb) };
+}
+
+/** Render a value with character-level diff highlighting and smart truncation.
+ *  side: 'a' or 'b'. Returns HTML string. */
+function highlightDiffVal(val, diff, side, maxLen) {
+  if (!val) return '<span style="color:var(--overlay)">(empty)</span>';
+  if (!diff) return esc(truncVal(val, maxLen));
+  const mid = side === 'a' ? diff.midA : diff.midB;
+  const prefix = diff.prefix;
+  const suffix = side === 'a' ? diff.suffixA : diff.suffixB;
+  const hlClass = mid.length === 0 ? (side === 'a' ? 'diff-hl-del' : 'diff-hl-ins') : 'diff-hl';
+  // Fits without truncation
+  if (val.length <= maxLen + 1) {
+    if (mid.length === 0) {
+      // Pure deletion/insertion on this side — mark insertion point
+      return esc(prefix) + '<span class="' + (side === 'a' ? 'diff-hl-del' : 'diff-hl-ins') + '">\u2039\u203a</span>' + esc(suffix);
+    }
+    return esc(prefix) + '<span class="' + hlClass + '">' + esc(mid) + '</span>' + esc(suffix);
+  }
+  // Smart truncation: ensure the diff region is visible
+  const midLen = Math.max(mid.length, 1);
+  const budget = maxLen - midLen;
+  if (budget < 4) {
+    // Diff itself exceeds budget
+    return '<span class="' + hlClass + '">' + esc(mid.substring(0, maxLen)) + '</span>\u2026';
+  }
+  const before = Math.min(Math.floor(budget / 2), prefix.length);
+  const after = Math.min(budget - before, suffix.length);
+  let r = '';
+  if (before < prefix.length) r += '\u2026';
+  r += esc(prefix.substring(prefix.length - before));
+  if (mid.length === 0) {
+    r += '<span class="' + (side === 'a' ? 'diff-hl-del' : 'diff-hl-ins') + '">\u2039\u203a</span>';
+  } else {
+    const midDisp = mid.length > maxLen - before - after ? mid.substring(0, maxLen - before - after) + '\u2026' : mid;
+    r += '<span class="' + hlClass + '">' + esc(midDisp) + '</span>';
+  }
+  r += esc(suffix.substring(0, after));
+  if (after < suffix.length) r += '\u2026';
+  return r;
+}
+
+/** Render full value with character-level diff highlighting (no truncation, for detail panel). */
+function highlightDiffFull(val, diff, side) {
+  if (!val) return '<em style="color:var(--overlay)">empty</em>';
+  if (!diff) return esc(val);
+  const mid = side === 'a' ? diff.midA : diff.midB;
+  const prefix = diff.prefix;
+  const suffix = side === 'a' ? diff.suffixA : diff.suffixB;
+  if (mid.length === 0) {
+    return esc(prefix) + '<span class="' + (side === 'a' ? 'diff-hl-del' : 'diff-hl-ins') + '">\u2039\u203a</span>' + esc(suffix);
+  }
+  const hlClass = 'diff-hl';
+  return esc(prefix) + '<span class="' + hlClass + '">' + esc(mid) + '</span>' + esc(suffix);
+}
+
 function renderDiffTable() {
   const tbody = document.getElementById('diffBody');
   tbody.innerHTML = '';
@@ -2687,8 +2758,21 @@ function renderDiffTable() {
       tr.dataset.fieldNum = fd.fieldNum;
       tr.dataset.status = fd.status;
 
-      const dispA = fd.status === 'b_only' ? '<span style="color:var(--overlay)">\u2014</span>' : esc(truncVal(valA, 28));
-      const dispB = fd.status === 'a_only' ? '<span style="color:var(--overlay)">\u2014</span>' : esc(truncVal(valB, 28));
+      let dispA, dispB;
+      if (fd.status === 'modified') {
+        const cd = charDiff(valA, valB);
+        dispA = highlightDiffVal(valA, cd, 'a', 28);
+        dispB = highlightDiffVal(valB, cd, 'b', 28);
+      } else if (fd.status === 'b_only') {
+        dispA = '<span style="color:var(--overlay)">\u2014</span>';
+        dispB = esc(truncVal(valB, 28));
+      } else if (fd.status === 'a_only') {
+        dispA = esc(truncVal(valA, 28));
+        dispB = '<span style="color:var(--overlay)">\u2014</span>';
+      } else {
+        dispA = esc(truncVal(valA, 28));
+        dispB = esc(truncVal(valB, 28));
+      }
       const statusClass = fd.status;
       const statusLabel = {modified: 'modified', a_only: 'A only', b_only: 'B only', identical: 'identical'}[fd.status];
 
@@ -2747,11 +2831,10 @@ function showDiffDetail(segDiff, fd, version) {
 
   const rawA = fd.valueA != null ? fd.valueA : '';
   const rawB = fd.valueB != null ? fd.valueB : '';
-  const rawADisp = rawA || '<em style="color:var(--overlay)">empty</em>';
-  const rawBDisp = rawB || '<em style="color:var(--overlay)">empty</em>';
+  const rawDiff = (fd.status === 'modified') ? charDiff(rawA, rawB) : null;
   html += '<tr><td class="ct-name">Raw</td><td class="ct-val" style="word-break:break-all">' +
-    (rawA ? esc(rawA) : rawADisp) + '</td><td class="ct-val" style="word-break:break-all">' +
-    (rawB ? esc(rawB) : rawBDisp) + '</td></tr>';
+    highlightDiffFull(rawA, rawDiff, 'a') + '</td><td class="ct-val" style="word-break:break-all">' +
+    highlightDiffFull(rawB, rawDiff, 'b') + '</td></tr>';
 
   // Component breakdown if composite type
   const dt = fDef ? fDef.dt : null;
@@ -2767,9 +2850,10 @@ function showDiffDetail(segDiff, fd, version) {
       const cName = cDef ? cDef.name : 'Component ' + (i + 1);
       const changed = cValA !== cValB;
       const style = changed ? ' style="background:rgba(250,179,135,0.1)"' : '';
+      const cDiff = changed ? charDiff(cValA, cValB) : null;
       html += '<tr' + style + '><td class="ct-name">' + (i + 1) + '. ' + esc(cName) + '</td>' +
-        '<td class="ct-val">' + (cValA ? esc(cValA) : '<em style="color:var(--overlay)">empty</em>') + '</td>' +
-        '<td class="ct-val">' + (cValB ? esc(cValB) : '<em style="color:var(--overlay)">empty</em>') + '</td></tr>';
+        '<td class="ct-val">' + highlightDiffFull(cValA, cDiff, 'a') + '</td>' +
+        '<td class="ct-val">' + highlightDiffFull(cValB, cDiff, 'b') + '</td></tr>';
     }
   }
 

--- a/hl7-viewer.html
+++ b/hl7-viewer.html
@@ -210,6 +210,55 @@ font-size:11px;color:var(--subtext);flex-shrink:0;gap:12px}
 #profileValidation .pv-orange{color:var(--orange)}
 #profileValidation .pv-blue{color:var(--blue)}
 #profileValidation .pv-yellow{color:var(--yellow)}
+/* Compare tab */
+#compareTab{display:none;flex-direction:column}
+#compareTab.active{display:flex!important}
+#compareInput{padding:8px;border-bottom:1px solid var(--bg3)}
+#compareInput.collapsed{display:none}
+#compareMsgInput{width:100%;height:100px;background:var(--bg2);color:var(--text);border:2px dashed var(--surface);
+border-radius:6px;padding:8px;font-family:inherit;font-size:13px;resize:vertical}
+#compareMsgInput:focus{outline:none;border-color:var(--blue)}
+#compareActions{display:flex;gap:8px;margin-top:6px;align-items:center}
+#compareSummary{display:none;padding:6px 12px;background:var(--bg2);border-bottom:1px solid var(--bg3);
+font-size:12px;color:var(--subtext);align-items:center;gap:12px}
+#compareSummary.active{display:flex}
+#compareSummary .cs-count{color:var(--orange);font-weight:500}
+#compareSummary .cs-modified{color:var(--orange)}
+#compareSummary .cs-a-only{color:var(--red)}
+#compareSummary .cs-b-only{color:var(--green)}
+#compareFilter{margin-left:auto;display:flex;gap:4px;align-items:center}
+#compareFilter label{color:var(--subtext);font-size:11px;cursor:pointer}
+#compareFilter input{accent-color:var(--blue);cursor:pointer}
+#diffTableWrap{flex:1;overflow:auto}
+#diffTable{width:100%;border-collapse:collapse}
+#diffTable th{position:sticky;top:0;background:var(--bg2);color:var(--subtext);
+font-weight:600;font-size:11px;text-transform:uppercase;letter-spacing:0.5px;
+text-align:left;padding:6px 8px;border-bottom:1px solid var(--bg3);z-index:1}
+#diffTable td{padding:4px 8px;border-bottom:1px solid var(--bg3);
+vertical-align:top;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;max-width:260px}
+#diffTable tr{cursor:pointer}
+#diffTable tr:hover{background:var(--bg3)}
+#diffTable tr.selected{background:rgba(137,180,250,0.12)}
+#diffTable tr.diff-seg-header{background:var(--bg2)}
+#diffTable tr.diff-seg-header td{padding:6px 8px;font-weight:700;color:var(--rose);
+border-bottom:1px solid var(--surface)}
+#diffTable tr.diff-modified{border-left:3px solid var(--orange)}
+#diffTable tr.diff-a-only{background:rgba(243,139,168,0.06);border-left:3px solid var(--red)}
+#diffTable tr.diff-b-only{background:rgba(166,227,161,0.06);border-left:3px solid var(--green)}
+#diffTable tr.diff-identical{opacity:0.5}
+#diffTable .addr{color:var(--blue);font-weight:500}
+#diffTable .fname{color:var(--green)}
+#diffTable .fval{color:var(--text);font-family:inherit}
+#diffTable .fval.empty{color:var(--overlay);font-style:italic}
+#diffTable .diff-status{font-size:10px;padding:1px 6px;border-radius:3px;white-space:nowrap}
+#diffTable .diff-status.modified{background:rgba(250,179,135,0.2);color:var(--orange)}
+#diffTable .diff-status.a-only{background:rgba(243,139,168,0.2);color:var(--red)}
+#diffTable .diff-status.b-only{background:rgba(166,227,161,0.2);color:var(--green)}
+#diffTable .diff-status.identical{background:rgba(166,173,200,0.1);color:var(--subtext)}
+#compareIndicator{display:none;align-items:center;gap:6px;background:var(--bg3);
+border-radius:4px;padding:2px 8px;font-size:12px;color:var(--blue)}
+#compareIndicator .unload{cursor:pointer;color:var(--subtext);font-size:14px}
+#compareIndicator .unload:hover{color:var(--red)}
 </style>
 </head>
 <body>
@@ -223,6 +272,7 @@ font-size:11px;color:var(--subtext);flex-shrink:0;gap:12px}
 <button class="tb-btn" onclick="document.getElementById('profileFile').click()">Load Profile</button>
 <input type="file" id="profileFile" accept=".json">
 <div id="profileIndicator"><span id="profileName"></span><span class="unload" title="Unload profile" onclick="unloadProfile()">&#x2715;</span></div>
+<div id="compareIndicator"><span id="compareLabel"></span><span class="unload" title="Exit compare" onclick="exitCompare()">&#x2715;</span></div>
 <button id="anonBtn" class="tb-btn" onclick="toggleAnonymize()" title="Anonymize patient data (Ctrl+Shift+A)">Anon</button>
 <label class="anon-checkbox" title="Use Estonian non-ASCII names (&#xD5;, &#xD6;, &#xDC;, &#xC4;, &#x17D;, &#x160;)"><input type="checkbox" id="anonNonAscii" onchange="onNonAsciiChange()">Non-ASCII</label>
 <button class="tb-btn" onclick="showHelp()" title="Profile documentation &amp; help">?</button>
@@ -245,6 +295,7 @@ font-size:11px;color:var(--subtext);flex-shrink:0;gap:12px}
 <div class="tab active" data-tab="inputTab" onclick="switchTab(this)">Input</div>
 <div class="tab" data-tab="parsedTab" onclick="switchTab(this)">Parsed</div>
 <div class="tab" data-tab="rawTab" onclick="switchTab(this)">Raw</div>
+<div class="tab" data-tab="compareTab" onclick="switchTab(this)">Compare</div>
 </div>
 <div id="inputTab" class="tab-content active">
 <div id="inputArea">
@@ -267,6 +318,30 @@ font-size:11px;color:var(--subtext);flex-shrink:0;gap:12px}
 </div>
 <div id="rawTab" class="tab-content">
 <div id="rawWrap"><div id="rawContent"></div></div>
+</div>
+<div id="compareTab" class="tab-content">
+<div id="compareInput">
+<textarea id="compareMsgInput" placeholder="Paste Message B here, or use Open to load a file..."></textarea>
+<div id="compareActions">
+<button class="tb-btn" onclick="runCompare()">Compare</button>
+<button class="tb-btn" onclick="document.getElementById('compareFile').click()">Open B</button>
+<input type="file" id="compareFile" accept=".hl7,.txt,.dat,.msg" style="display:none">
+<span id="compareStatus" style="color:var(--subtext);font-size:12px;margin-left:8px"></span>
+</div>
+</div>
+<div id="compareSummary">
+<span id="compareSummaryText"></span>
+<div id="compareFilter">
+<label><input type="checkbox" id="showIdenticalCheck" onchange="rerenderDiffTable()">Show identical</label>
+</div>
+</div>
+<div id="diffTableWrap">
+<table id="diffTable"><thead><tr>
+<th style="width:100px">Address</th><th style="width:170px">Field Name</th>
+<th style="width:200px">Message A</th><th style="width:200px">Message B</th>
+<th style="width:70px">Status</th>
+</tr></thead><tbody id="diffBody"></tbody></table>
+</div>
 </div>
 </div>
 <div id="rightPanel">
@@ -2382,6 +2457,7 @@ function clearAll() {
   document.getElementById('anonIndicator').style.display = 'none';
   document.getElementById('encodingInfo').style.display = 'none';
   document.getElementById('profileValidation').style.display = 'none';
+  exitCompare();
   clearDetail();
   setStatus('');
   switchTab(document.querySelector('[data-tab="inputTab"]'));
@@ -2398,6 +2474,308 @@ function loadSample() {
   setStatus('Sample message loaded');
 }
 
+// ========== COMPARE / DIFF ==========
+let compareMessage = null;  // parsed message B
+let diffResult = null;      // result of diffMessages()
+let selectedDiffRow = null;
+
+function diffMessages(parsedA, parsedB) {
+  // Index segments by (name, repIndex)
+  const segMapA = new Map();
+  const segOrderA = [];
+  for (const seg of parsedA.segments) {
+    const key = seg.name + '#' + seg.repIndex;
+    segMapA.set(key, seg);
+    segOrderA.push(key);
+  }
+  const segMapB = new Map();
+  const segOrderB = [];
+  for (const seg of parsedB.segments) {
+    const key = seg.name + '#' + seg.repIndex;
+    segMapB.set(key, seg);
+    segOrderB.push(key);
+  }
+
+  // Union of keys preserving order
+  const allKeys = [...segOrderA];
+  const seen = new Set(allKeys);
+  for (const key of segOrderB) {
+    if (!seen.has(key)) { allKeys.push(key); seen.add(key); }
+  }
+
+  const segmentDiffs = [];
+  const counts = {total: 0, identical: 0, modified: 0, a_only: 0, b_only: 0};
+
+  for (const key of allKeys) {
+    const [segName, repIdxStr] = key.split('#');
+    const repIdx = parseInt(repIdxStr);
+    const segA = segMapA.get(key);
+    const segB = segMapB.get(key);
+
+    if (segA && !segB) {
+      const fieldDiffs = segA.fields.map(f => {
+        counts.a_only++; counts.total++;
+        return {address: makeAddr(segName, repIdx, f.fieldNum), fieldNum: f.fieldNum,
+          status: 'a_only', valueA: f.rawValue, valueB: null, fieldA: f, fieldB: null};
+      });
+      segmentDiffs.push({name: segName, repIndex: repIdx, status: 'a_only', fieldDiffs});
+    } else if (segB && !segA) {
+      const fieldDiffs = segB.fields.map(f => {
+        counts.b_only++; counts.total++;
+        return {address: makeAddr(segName, repIdx, f.fieldNum), fieldNum: f.fieldNum,
+          status: 'b_only', valueA: null, valueB: f.rawValue, fieldA: null, fieldB: f};
+      });
+      segmentDiffs.push({name: segName, repIndex: repIdx, status: 'b_only', fieldDiffs});
+    } else {
+      const fieldsA = new Map(segA.fields.map(f => [f.fieldNum, f]));
+      const fieldsB = new Map(segB.fields.map(f => [f.fieldNum, f]));
+      const allNums = [...new Set([...fieldsA.keys(), ...fieldsB.keys()])].sort((a, b) => a - b);
+      const fieldDiffs = [];
+      let segStatus = 'identical';
+      for (const fnum of allNums) {
+        const fa = fieldsA.get(fnum);
+        const fb = fieldsB.get(fnum);
+        const addr = makeAddr(segName, repIdx, fnum);
+        let fd;
+        if (fa && !fb) {
+          fd = {address: addr, fieldNum: fnum, status: 'a_only',
+            valueA: fa.rawValue, valueB: null, fieldA: fa, fieldB: null};
+          segStatus = 'modified'; counts.a_only++;
+        } else if (fb && !fa) {
+          fd = {address: addr, fieldNum: fnum, status: 'b_only',
+            valueA: null, valueB: fb.rawValue, fieldA: null, fieldB: fb};
+          segStatus = 'modified'; counts.b_only++;
+        } else if (fa.rawValue === fb.rawValue) {
+          fd = {address: addr, fieldNum: fnum, status: 'identical',
+            valueA: fa.rawValue, valueB: fb.rawValue, fieldA: fa, fieldB: fb};
+          counts.identical++;
+        } else {
+          fd = {address: addr, fieldNum: fnum, status: 'modified',
+            valueA: fa.rawValue, valueB: fb.rawValue, fieldA: fa, fieldB: fb};
+          segStatus = 'modified'; counts.modified++;
+        }
+        counts.total++;
+        fieldDiffs.push(fd);
+      }
+      segmentDiffs.push({name: segName, repIndex: repIdx, status: segStatus, fieldDiffs});
+    }
+  }
+
+  return {
+    segmentDiffs, summary: counts,
+    versionA: parsedA.version, versionB: parsedB.version,
+    typeA: parsedA.messageType, typeB: parsedB.messageType
+  };
+}
+
+function makeAddr(segName, repIndex, fieldNum) {
+  return segName + (repIndex > 1 ? '[' + repIndex + ']' : '') + '-' + fieldNum;
+}
+
+function runCompare() {
+  if (!parsedMessage) {
+    setCompareStatus('Parse Message A first (Input tab)', true);
+    return;
+  }
+  const raw = document.getElementById('compareMsgInput').value;
+  if (!raw.trim()) {
+    setCompareStatus('Paste or open Message B', true);
+    return;
+  }
+  compareMessage = parseHL7(raw);
+  if (!compareMessage || compareMessage.segments.length === 0) {
+    setCompareStatus('Failed to parse Message B', true);
+    return;
+  }
+  diffResult = diffMessages(parsedMessage, compareMessage);
+  const s = diffResult.summary;
+  const diffCount = s.modified + s.a_only + s.b_only;
+  const segCount = diffResult.segmentDiffs.filter(sd => sd.status !== 'identical').length;
+  setCompareStatus('');
+
+  // Update summary bar
+  const summaryEl = document.getElementById('compareSummary');
+  const parts = [];
+  if (s.modified) parts.push('<span class="cs-modified">' + s.modified + ' modified</span>');
+  if (s.a_only) parts.push('<span class="cs-a-only">' + s.a_only + ' A\u2011only</span>');
+  if (s.b_only) parts.push('<span class="cs-b-only">' + s.b_only + ' B\u2011only</span>');
+  document.getElementById('compareSummaryText').innerHTML =
+    '<span class="cs-count">' + diffCount + ' difference' + (diffCount !== 1 ? 's' : '') +
+    '</span> across ' + segCount + ' segment' + (segCount !== 1 ? 's' : '') +
+    (parts.length ? ': ' + parts.join(', ') : '');
+  summaryEl.classList.add('active');
+
+  // Collapse input area
+  document.getElementById('compareInput').classList.add('collapsed');
+
+  // Show indicator in toolbar
+  const typeA = diffResult.typeA || '?';
+  const typeB = diffResult.typeB || '?';
+  const ind = document.getElementById('compareIndicator');
+  document.getElementById('compareLabel').textContent = 'Comparing: ' + typeA + ' vs ' + typeB;
+  ind.style.display = 'flex';
+
+  renderDiffTable();
+}
+
+function exitCompare() {
+  compareMessage = null;
+  diffResult = null;
+  selectedDiffRow = null;
+  document.getElementById('compareIndicator').style.display = 'none';
+  document.getElementById('compareSummary').classList.remove('active');
+  document.getElementById('compareInput').classList.remove('collapsed');
+  document.getElementById('diffBody').innerHTML = '';
+  document.getElementById('compareMsgInput').value = '';
+  setCompareStatus('');
+  clearDetail();
+}
+
+function setCompareStatus(msg, isError) {
+  const el = document.getElementById('compareStatus');
+  el.textContent = msg;
+  el.style.color = isError ? 'var(--red)' : 'var(--green)';
+}
+
+function rerenderDiffTable() {
+  if (diffResult) renderDiffTable();
+}
+
+function renderDiffTable() {
+  const tbody = document.getElementById('diffBody');
+  tbody.innerHTML = '';
+  if (!diffResult) return;
+
+  const showIdentical = document.getElementById('showIdenticalCheck').checked;
+  const versionA = resolveVersion(parsedMessage);
+  const versionB = resolveVersion(compareMessage);
+
+  for (const sd of diffResult.segmentDiffs) {
+    if (!showIdentical && sd.status === 'identical') continue;
+    const hasDiffs = sd.fieldDiffs.some(fd => fd.status !== 'identical');
+    if (!showIdentical && !hasDiffs) continue;
+
+    const version = sd.status !== 'b_only' ? versionA : versionB;
+    const segDef = getSegDef(sd.name, version);
+    const segDesc = segDef ? segDef.name : (sd.name.startsWith('Z') ? 'Custom Segment' : '');
+    const repLabel = sd.repIndex > 1 ? '[' + sd.repIndex + ']' : '';
+
+    // Segment header row
+    const hdr = document.createElement('tr');
+    hdr.className = 'diff-seg-header';
+    let statusBadge = '';
+    if (sd.status === 'a_only') statusBadge = ' <span style="color:var(--red);font-weight:400;font-size:11px">[A only]</span>';
+    else if (sd.status === 'b_only') statusBadge = ' <span style="color:var(--green);font-weight:400;font-size:11px">[B only]</span>';
+    hdr.innerHTML = '<td colspan="5">' + esc(sd.name + repLabel) +
+      (segDesc ? '  <span style="font-weight:400">' + esc(segDesc) + '</span>' : '') +
+      statusBadge + '</td>';
+    tbody.appendChild(hdr);
+
+    for (const fd of sd.fieldDiffs) {
+      if (!showIdentical && fd.status === 'identical') continue;
+
+      const fDef = getFieldDef(sd.name, fd.fieldNum, version);
+      const fname = fDef ? fDef.name : '';
+      const valA = fd.valueA != null ? fd.valueA : '';
+      const valB = fd.valueB != null ? fd.valueB : '';
+
+      const tr = document.createElement('tr');
+      tr.className = 'diff-' + fd.status;
+      tr.dataset.segName = sd.name;
+      tr.dataset.repIndex = sd.repIndex;
+      tr.dataset.fieldNum = fd.fieldNum;
+      tr.dataset.status = fd.status;
+
+      const dispA = fd.status === 'b_only' ? '<span style="color:var(--overlay)">\u2014</span>' : esc(truncVal(valA, 28));
+      const dispB = fd.status === 'a_only' ? '<span style="color:var(--overlay)">\u2014</span>' : esc(truncVal(valB, 28));
+      const statusClass = fd.status;
+      const statusLabel = {modified: 'modified', a_only: 'A only', b_only: 'B only', identical: 'identical'}[fd.status];
+
+      tr.innerHTML =
+        '<td class="addr">' + esc(fd.address) + '</td>' +
+        '<td class="fname">' + esc(fname) + '</td>' +
+        '<td class="fval">' + dispA + '</td>' +
+        '<td class="fval">' + dispB + '</td>' +
+        '<td><span class="diff-status ' + statusClass + '">' + statusLabel + '</span></td>';
+
+      tr.addEventListener('click', function() { selectDiffField(this, sd, fd, version); });
+      tbody.appendChild(tr);
+    }
+  }
+}
+
+function truncVal(val, max) {
+  if (!val) return '(empty)';
+  return val.length > max + 1 ? val.substring(0, max) + '\u2026' : val;
+}
+
+function selectDiffField(row, segDiff, fieldDiff, version) {
+  // Deselect previous
+  document.querySelectorAll('#diffTable tr.selected').forEach(r => r.classList.remove('selected'));
+  row.classList.add('selected');
+  selectedDiffRow = row;
+  showDiffDetail(segDiff, fieldDiff, version);
+}
+
+function showDiffDetail(segDiff, fd, version) {
+  const panel = document.getElementById('detailPanel');
+  const noSel = document.getElementById('noSelection');
+  noSel.style.display = 'none';
+  panel.style.display = 'block';
+
+  const fDef = getFieldDef(segDiff.name, fd.fieldNum, version);
+  const segDef = getSegDef(segDiff.name, version);
+
+  let html = '<h3>' + esc(fd.address) + ' <span class="diff-status ' + fd.status + '" style="font-size:11px">' +
+    ({modified:'modified', a_only:'A only', b_only:'B only', identical:'identical'}[fd.status]) + '</span></h3>';
+
+  // Field info
+  html += '<div class="detail-section"><h4>Field</h4><div class="detail-grid">';
+  html += '<span class="lbl">Segment</span><span class="val">' +
+    esc(segDiff.name) + (segDef ? ' - ' + esc(segDef.name) : '') + '</span>';
+  if (fDef) {
+    html += '<span class="lbl">Name</span><span class="val">' + esc(fDef.name) + '</span>';
+    html += '<span class="lbl">Data Type</span><span class="val">' + esc(fDef.dt) +
+      (DATA_TYPES[fDef.dt] ? ' - ' + esc(DATA_TYPES[fDef.dt].name) : '') + '</span>';
+  }
+  html += '</div></div>';
+
+  // Side-by-side values
+  html += '<div class="detail-section"><h4>Values</h4>';
+  html += '<table class="comp-table"><thead><tr><th></th><th>Message A</th><th>Message B</th></tr></thead><tbody>';
+
+  const rawA = fd.valueA != null ? fd.valueA : '';
+  const rawB = fd.valueB != null ? fd.valueB : '';
+  const rawADisp = rawA || '<em style="color:var(--overlay)">empty</em>';
+  const rawBDisp = rawB || '<em style="color:var(--overlay)">empty</em>';
+  html += '<tr><td class="ct-name">Raw</td><td class="ct-val" style="word-break:break-all">' +
+    (rawA ? esc(rawA) : rawADisp) + '</td><td class="ct-val" style="word-break:break-all">' +
+    (rawB ? esc(rawB) : rawBDisp) + '</td></tr>';
+
+  // Component breakdown if composite type
+  const dt = fDef ? fDef.dt : null;
+  const dtDef = dt ? DATA_TYPES[dt] : null;
+  if (dtDef && dtDef.components) {
+    const compsA = fd.fieldA ? fd.fieldA.components : [];
+    const compsB = fd.fieldB ? fd.fieldB.components : [];
+    const maxLen = Math.max(dtDef.components.length, compsA.length, compsB.length);
+    for (let i = 0; i < maxLen; i++) {
+      const cDef = dtDef.components[i];
+      const cValA = i < compsA.length ? compsA[i].value : '';
+      const cValB = i < compsB.length ? compsB[i].value : '';
+      const cName = cDef ? cDef.name : 'Component ' + (i + 1);
+      const changed = cValA !== cValB;
+      const style = changed ? ' style="background:rgba(250,179,135,0.1)"' : '';
+      html += '<tr' + style + '><td class="ct-name">' + (i + 1) + '. ' + esc(cName) + '</td>' +
+        '<td class="ct-val">' + (cValA ? esc(cValA) : '<em style="color:var(--overlay)">empty</em>') + '</td>' +
+        '<td class="ct-val">' + (cValB ? esc(cValB) : '<em style="color:var(--overlay)">empty</em>') + '</td></tr>';
+    }
+  }
+
+  html += '</tbody></table></div>';
+  panel.innerHTML = html;
+}
+
 // ========== EVENT LISTENERS ==========
 document.getElementById('hl7File').addEventListener('change', function(e) {
   if (e.target.files.length > 0) openHL7File(e.target.files[0]);
@@ -2407,6 +2785,22 @@ document.getElementById('hl7File').addEventListener('change', function(e) {
 document.getElementById('profileFile').addEventListener('change', function(e) {
   if (e.target.files.length > 0) loadProfile(e.target.files[0]);
   e.target.value = ''; // reset for re-upload
+});
+
+document.getElementById('compareFile').addEventListener('change', function(e) {
+  if (e.target.files.length > 0) {
+    const file = e.target.files[0];
+    const reader = new FileReader();
+    reader.onload = function(ev) {
+      const bytes = new Uint8Array(ev.target.result);
+      const enc = detectEncoding(bytes.buffer);
+      const decoder = new TextDecoder(enc.decoderLabel);
+      document.getElementById('compareMsgInput').value = decoder.decode(bytes.buffer);
+      setCompareStatus('Loaded: ' + file.name);
+    };
+    reader.readAsArrayBuffer(file);
+  }
+  e.target.value = '';
 });
 
 document.getElementById('searchInput').addEventListener('input', applySearch);

--- a/hl7-viewer.html
+++ b/hl7-viewer.html
@@ -332,6 +332,7 @@ border-radius:4px;padding:2px 8px;font-size:12px;color:var(--blue)}
 <div id="compareSummary">
 <span id="compareSummaryText"></span>
 <div id="compareFilter">
+<button class="tb-btn" onclick="exitCompare()" title="Clear comparison and start over">Reset</button>
 <label><input type="checkbox" id="showIdenticalCheck" onchange="rerenderDiffTable()">Show identical</label>
 </div>
 </div>

--- a/hl7view/diff.py
+++ b/hl7view/diff.py
@@ -1,0 +1,194 @@
+"""HL7 message comparison: field-level diff between two parsed messages."""
+
+from dataclasses import dataclass, field
+
+
+@dataclass
+class FieldDiff:
+    """Difference record for a single field."""
+    address: str
+    field_num: int
+    status: str          # 'identical', 'modified', 'a_only', 'b_only'
+    value_a: str         # raw_value from message A (or None)
+    value_b: str         # raw_value from message B (or None)
+    field_a: object = None  # Field dataclass from A (or None)
+    field_b: object = None  # Field dataclass from B (or None)
+
+
+@dataclass
+class SegmentDiff:
+    """Difference record for a segment (by name + rep_index)."""
+    name: str
+    rep_index: int
+    status: str          # 'identical', 'modified', 'a_only', 'b_only'
+    field_diffs: list    # list of FieldDiff
+
+
+@dataclass
+class MessageDiff:
+    """Top-level diff result between two messages."""
+    segment_diffs: list  # list of SegmentDiff
+    summary: dict        # {'total_fields', 'identical', 'modified', 'a_only', 'b_only'}
+    version_a: str
+    version_b: str
+    type_a: str
+    type_b: str
+
+
+def _seg_key(seg):
+    """Return (name, rep_index) tuple for segment indexing."""
+    return (seg.name, seg.rep_index)
+
+
+def _build_field_map(seg):
+    """Build {field_num: field} dict for a segment."""
+    return {f.field_num: f for f in seg.fields}
+
+
+def diff_messages(parsed_a, parsed_b):
+    """Compare two ParsedMessage objects field-by-field.
+
+    Returns a MessageDiff with per-segment, per-field comparison results.
+    """
+    # Index segments by (name, rep_index), preserving order
+    seg_map_a = {}
+    seg_order_a = []
+    for seg in parsed_a.segments:
+        key = _seg_key(seg)
+        seg_map_a[key] = seg
+        seg_order_a.append(key)
+
+    seg_map_b = {}
+    seg_order_b = []
+    for seg in parsed_b.segments:
+        key = _seg_key(seg)
+        seg_map_b[key] = seg
+        seg_order_b.append(key)
+
+    # Union of segment keys, preserving order (A first, then B-only)
+    all_keys = list(seg_order_a)
+    seen = set(all_keys)
+    for key in seg_order_b:
+        if key not in seen:
+            all_keys.append(key)
+            seen.add(key)
+
+    segment_diffs = []
+    counts = {'total_fields': 0, 'identical': 0, 'modified': 0, 'a_only': 0, 'b_only': 0}
+
+    for key in all_keys:
+        seg_name, rep_idx = key
+        seg_a = seg_map_a.get(key)
+        seg_b = seg_map_b.get(key)
+
+        if seg_a and not seg_b:
+            # Segment only in A
+            field_diffs = []
+            for fld in seg_a.fields:
+                addr = _make_address(seg_name, rep_idx, fld.field_num)
+                fd = FieldDiff(
+                    address=addr, field_num=fld.field_num,
+                    status='a_only',
+                    value_a=fld.raw_value, value_b=None,
+                    field_a=fld, field_b=None,
+                )
+                field_diffs.append(fd)
+                counts['a_only'] += 1
+                counts['total_fields'] += 1
+            segment_diffs.append(SegmentDiff(
+                name=seg_name, rep_index=rep_idx,
+                status='a_only', field_diffs=field_diffs,
+            ))
+
+        elif seg_b and not seg_a:
+            # Segment only in B
+            field_diffs = []
+            for fld in seg_b.fields:
+                addr = _make_address(seg_name, rep_idx, fld.field_num)
+                fd = FieldDiff(
+                    address=addr, field_num=fld.field_num,
+                    status='b_only',
+                    value_a=None, value_b=fld.raw_value,
+                    field_a=None, field_b=fld,
+                )
+                field_diffs.append(fd)
+                counts['b_only'] += 1
+                counts['total_fields'] += 1
+            segment_diffs.append(SegmentDiff(
+                name=seg_name, rep_index=rep_idx,
+                status='b_only', field_diffs=field_diffs,
+            ))
+
+        else:
+            # Segment in both — compare fields
+            fields_a = _build_field_map(seg_a)
+            fields_b = _build_field_map(seg_b)
+            all_fnums = sorted(set(fields_a.keys()) | set(fields_b.keys()))
+
+            field_diffs = []
+            seg_status = 'identical'
+
+            for fnum in all_fnums:
+                fa = fields_a.get(fnum)
+                fb = fields_b.get(fnum)
+                addr = _make_address(seg_name, rep_idx, fnum)
+
+                if fa and not fb:
+                    fd = FieldDiff(
+                        address=addr, field_num=fnum,
+                        status='a_only',
+                        value_a=fa.raw_value, value_b=None,
+                        field_a=fa, field_b=None,
+                    )
+                    seg_status = 'modified'
+                    counts['a_only'] += 1
+                elif fb and not fa:
+                    fd = FieldDiff(
+                        address=addr, field_num=fnum,
+                        status='b_only',
+                        value_a=None, value_b=fb.raw_value,
+                        field_a=None, field_b=fb,
+                    )
+                    seg_status = 'modified'
+                    counts['b_only'] += 1
+                elif fa.raw_value == fb.raw_value:
+                    fd = FieldDiff(
+                        address=addr, field_num=fnum,
+                        status='identical',
+                        value_a=fa.raw_value, value_b=fb.raw_value,
+                        field_a=fa, field_b=fb,
+                    )
+                    counts['identical'] += 1
+                else:
+                    fd = FieldDiff(
+                        address=addr, field_num=fnum,
+                        status='modified',
+                        value_a=fa.raw_value, value_b=fb.raw_value,
+                        field_a=fa, field_b=fb,
+                    )
+                    seg_status = 'modified'
+                    counts['modified'] += 1
+
+                counts['total_fields'] += 1
+                field_diffs.append(fd)
+
+            segment_diffs.append(SegmentDiff(
+                name=seg_name, rep_index=rep_idx,
+                status=seg_status, field_diffs=field_diffs,
+            ))
+
+    return MessageDiff(
+        segment_diffs=segment_diffs,
+        summary=counts,
+        version_a=parsed_a.version,
+        version_b=parsed_b.version,
+        type_a=parsed_a.message_type,
+        type_b=parsed_b.message_type,
+    )
+
+
+def _make_address(seg_name, rep_index, field_num):
+    """Build field address string like 'PID-3' or 'OBX[2]-5'."""
+    if rep_index > 1:
+        return f'{seg_name}[{rep_index}]-{field_num}'
+    return f'{seg_name}-{field_num}'

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -1,0 +1,271 @@
+"""Tests for hl7view.diff — field-level message comparison."""
+
+import copy
+
+import pytest
+
+from hl7view.parser import parse_hl7, reparse_field, rebuild_raw_line
+from hl7view.diff import diff_messages, FieldDiff, SegmentDiff, MessageDiff
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _modify_field(parsed, seg_name, field_num, new_value, rep_index=1):
+    """Modify a field in a parsed message (returns a deep copy)."""
+    msg = copy.deepcopy(parsed)
+    for seg in msg.segments:
+        if seg.name == seg_name and seg.rep_index == rep_index:
+            for fld in seg.fields:
+                if fld.field_num == field_num:
+                    reparse_field(fld, new_value)
+                    seg.raw_line = rebuild_raw_line(seg.name, seg.fields)
+                    return msg
+    raise ValueError(f"Field {seg_name}-{field_num} not found")
+
+
+def _remove_segment(parsed, seg_name, rep_index=1):
+    """Remove a segment from a parsed message (returns a deep copy)."""
+    msg = copy.deepcopy(parsed)
+    msg.segments = [s for s in msg.segments
+                    if not (s.name == seg_name and s.rep_index == rep_index)]
+    return msg
+
+
+def _diff_statuses(diff_result):
+    """Extract flat list of (address, status) from a MessageDiff."""
+    result = []
+    for sd in diff_result.segment_diffs:
+        for fd in sd.field_diffs:
+            result.append((fd.address, fd.status))
+    return result
+
+
+def _changed_fields(diff_result):
+    """Extract field diffs that are not identical."""
+    return [fd for sd in diff_result.segment_diffs
+            for fd in sd.field_diffs if fd.status != 'identical']
+
+
+# ---------------------------------------------------------------------------
+# Tests: identical messages
+# ---------------------------------------------------------------------------
+
+class TestIdenticalMessages:
+
+    def test_identical_adt(self, adt_parsed):
+        result = diff_messages(adt_parsed, copy.deepcopy(adt_parsed))
+        assert result.summary['modified'] == 0
+        assert result.summary['a_only'] == 0
+        assert result.summary['b_only'] == 0
+        assert result.summary['identical'] == result.summary['total_fields']
+
+    def test_identical_oru(self, oru_parsed):
+        result = diff_messages(oru_parsed, copy.deepcopy(oru_parsed))
+        assert result.summary['modified'] == 0
+        assert result.summary['a_only'] == 0
+        assert result.summary['b_only'] == 0
+
+    def test_all_segment_diffs_identical(self, adt_parsed):
+        result = diff_messages(adt_parsed, copy.deepcopy(adt_parsed))
+        for sd in result.segment_diffs:
+            assert sd.status == 'identical'
+
+    def test_metadata_preserved(self, adt_parsed):
+        result = diff_messages(adt_parsed, copy.deepcopy(adt_parsed))
+        assert result.version_a == '2.5'
+        assert result.version_b == '2.5'
+        assert result.type_a == 'ADT^A01'
+        assert result.type_b == 'ADT^A01'
+
+
+# ---------------------------------------------------------------------------
+# Tests: single field modified
+# ---------------------------------------------------------------------------
+
+class TestSingleFieldModified:
+
+    def test_modify_pid_name(self, adt_parsed):
+        msg_b = _modify_field(adt_parsed, 'PID', 5, 'DOE^JOHN')
+        result = diff_messages(adt_parsed, msg_b)
+        assert result.summary['modified'] == 1
+        changed = _changed_fields(result)
+        assert len(changed) == 1
+        assert changed[0].address == 'PID-5'
+        assert changed[0].status == 'modified'
+        assert 'Tamm' in changed[0].value_a
+        assert changed[0].value_b == 'DOE^JOHN'
+
+    def test_modify_msh_control_id(self, adt_parsed):
+        msg_b = _modify_field(adt_parsed, 'MSH', 10, 'MSG99999')
+        result = diff_messages(adt_parsed, msg_b)
+        changed = _changed_fields(result)
+        modified = [f for f in changed if f.status == 'modified']
+        assert len(modified) == 1
+        assert modified[0].address == 'MSH-10'
+
+    def test_modify_preserves_other_fields(self, adt_parsed):
+        msg_b = _modify_field(adt_parsed, 'PID', 5, 'DOE^JOHN')
+        result = diff_messages(adt_parsed, msg_b)
+        # All other fields should be identical
+        assert result.summary['identical'] == result.summary['total_fields'] - 1
+
+
+# ---------------------------------------------------------------------------
+# Tests: added/removed segments
+# ---------------------------------------------------------------------------
+
+class TestSegmentAddRemove:
+
+    def test_segment_only_in_a(self, adt_parsed):
+        msg_b = _remove_segment(adt_parsed, 'NK1')
+        result = diff_messages(adt_parsed, msg_b)
+        nk1_diffs = [sd for sd in result.segment_diffs if sd.name == 'NK1']
+        assert len(nk1_diffs) == 1
+        assert nk1_diffs[0].status == 'a_only'
+        assert all(fd.status == 'a_only' for fd in nk1_diffs[0].field_diffs)
+
+    def test_segment_only_in_b(self, adt_parsed):
+        msg_a = _remove_segment(adt_parsed, 'NK1')
+        result = diff_messages(msg_a, adt_parsed)
+        nk1_diffs = [sd for sd in result.segment_diffs if sd.name == 'NK1']
+        assert len(nk1_diffs) == 1
+        assert nk1_diffs[0].status == 'b_only'
+        assert all(fd.status == 'b_only' for fd in nk1_diffs[0].field_diffs)
+
+    def test_a_only_counts(self, adt_parsed):
+        msg_b = _remove_segment(adt_parsed, 'NK1')
+        result = diff_messages(adt_parsed, msg_b)
+        # NK1 has fields — they should all be a_only
+        nk1_seg = [s for s in adt_parsed.segments if s.name == 'NK1'][0]
+        assert result.summary['a_only'] == len(nk1_seg.fields)
+
+    def test_removed_evn_segment(self, adt_parsed):
+        msg_b = _remove_segment(adt_parsed, 'EVN')
+        result = diff_messages(adt_parsed, msg_b)
+        evn_diffs = [sd for sd in result.segment_diffs if sd.name == 'EVN']
+        assert evn_diffs[0].status == 'a_only'
+
+
+# ---------------------------------------------------------------------------
+# Tests: different OBX counts (ORU has 5 OBX segments)
+# ---------------------------------------------------------------------------
+
+class TestDifferentOBXCounts:
+
+    def test_oru_fewer_obx_in_b(self, oru_parsed):
+        """Remove OBX[5] from B — should show as a_only."""
+        msg_b = _remove_segment(oru_parsed, 'OBX', rep_index=5)
+        result = diff_messages(oru_parsed, msg_b)
+        obx5_diffs = [sd for sd in result.segment_diffs
+                      if sd.name == 'OBX' and sd.rep_index == 5]
+        assert len(obx5_diffs) == 1
+        assert obx5_diffs[0].status == 'a_only'
+
+    def test_oru_extra_obx_in_b(self, oru_parsed):
+        """Remove OBX[5] from A — should show as b_only."""
+        msg_a = _remove_segment(oru_parsed, 'OBX', rep_index=5)
+        result = diff_messages(msg_a, oru_parsed)
+        obx5_diffs = [sd for sd in result.segment_diffs
+                      if sd.name == 'OBX' and sd.rep_index == 5]
+        assert len(obx5_diffs) == 1
+        assert obx5_diffs[0].status == 'b_only'
+
+    def test_modified_obx_value(self, oru_parsed):
+        """Modify OBX[1]-5 (glucose value) and check diff."""
+        msg_b = _modify_field(oru_parsed, 'OBX', 5, '6.2', rep_index=1)
+        result = diff_messages(oru_parsed, msg_b)
+        changed = _changed_fields(result)
+        obx1_5 = [f for f in changed if f.address == 'OBX-5']
+        assert len(obx1_5) == 1
+        assert obx1_5[0].value_a == '5.4'
+        assert obx1_5[0].value_b == '6.2'
+
+
+# ---------------------------------------------------------------------------
+# Tests: empty vs populated fields
+# ---------------------------------------------------------------------------
+
+class TestEmptyVsPopulated:
+
+    def test_field_cleared(self, adt_parsed):
+        """Clear PID-8 (sex) in B — should show as modified."""
+        msg_b = _modify_field(adt_parsed, 'PID', 8, '')
+        result = diff_messages(adt_parsed, msg_b)
+        changed = _changed_fields(result)
+        pid8 = [f for f in changed if f.address == 'PID-8']
+        assert len(pid8) == 1
+        assert pid8[0].status == 'modified'
+        assert pid8[0].value_a == 'M'
+        assert pid8[0].value_b == ''
+
+    def test_field_populated(self, adt_parsed):
+        """Set PID-8 to 'F' in B from 'M' — modified."""
+        msg_b = _modify_field(adt_parsed, 'PID', 8, 'F')
+        result = diff_messages(adt_parsed, msg_b)
+        changed = _changed_fields(result)
+        pid8 = [f for f in changed if f.address == 'PID-8']
+        assert len(pid8) == 1
+        assert pid8[0].value_a == 'M'
+        assert pid8[0].value_b == 'F'
+
+
+# ---------------------------------------------------------------------------
+# Tests: cross-message comparison (ADT vs ORU)
+# ---------------------------------------------------------------------------
+
+class TestCrossMessage:
+
+    def test_different_message_types(self, adt_parsed, oru_parsed):
+        result = diff_messages(adt_parsed, oru_parsed)
+        assert result.type_a == 'ADT^A01'
+        assert result.type_b == 'ORU^R01'
+        # Should have both a_only and b_only segments
+        assert result.summary['a_only'] > 0
+        assert result.summary['b_only'] > 0
+        # MSH exists in both — some fields should be modified
+        assert result.summary['modified'] > 0
+
+    def test_segment_order_preserved(self, adt_parsed, oru_parsed):
+        """A-side segments come first in diff order."""
+        result = diff_messages(adt_parsed, oru_parsed)
+        seg_names = [sd.name for sd in result.segment_diffs]
+        # MSH, EVN, PID, NK1, PV1 from A should appear before ORC, OBR, OBX, NTE from B
+        msh_idx = seg_names.index('MSH')
+        assert msh_idx == 0  # MSH is first in both
+
+    def test_shared_segments_compared(self, adt_parsed, oru_parsed):
+        """PID appears in both — should be compared field by field."""
+        result = diff_messages(adt_parsed, oru_parsed)
+        pid_diffs = [sd for sd in result.segment_diffs if sd.name == 'PID']
+        assert len(pid_diffs) == 1
+        assert pid_diffs[0].status == 'modified'  # PID has differences
+
+
+# ---------------------------------------------------------------------------
+# Tests: MessageDiff structure
+# ---------------------------------------------------------------------------
+
+class TestDiffStructure:
+
+    def test_summary_counts_consistent(self, adt_parsed):
+        msg_b = _modify_field(adt_parsed, 'PID', 5, 'DOE^JOHN')
+        result = diff_messages(adt_parsed, msg_b)
+        s = result.summary
+        assert s['total_fields'] == s['identical'] + s['modified'] + s['a_only'] + s['b_only']
+
+    def test_field_diff_has_both_fields(self, adt_parsed):
+        msg_b = _modify_field(adt_parsed, 'PID', 5, 'DOE^JOHN')
+        result = diff_messages(adt_parsed, msg_b)
+        for sd in result.segment_diffs:
+            for fd in sd.field_diffs:
+                if fd.status == 'identical' or fd.status == 'modified':
+                    assert fd.field_a is not None
+                    assert fd.field_b is not None
+                elif fd.status == 'a_only':
+                    assert fd.field_a is not None
+                    assert fd.field_b is None
+                elif fd.status == 'b_only':
+                    assert fd.field_a is None
+                    assert fd.field_b is not None


### PR DESCRIPTION
## Summary

- **Field-level diff** across all interfaces: web viewer Compare tab, CLI `--diff` flag, and MCP `hl7_diff` tool
- **Character-level highlighting** on modified fields — pinpoints the exact changed characters (e.g. a single digit in a timestamp), with smart truncation that keeps the diff region visible in long values
- Core diff engine in `hl7view/diff.py` with 21 new tests (63 total, all passing)

## What's included

| Interface | Usage |
|-----------|-------|
| **Web viewer** | Parse message A, switch to Compare tab, paste/open message B, click Compare |
| **CLI** | `hl7view file1.hl7 file2.hl7 --diff` (add `-e` to include identical fields) |
| **MCP** | `hl7_diff(message_a, message_b)` returns structured JSON diff |

## Test plan

- [x] `venv/bin/pytest tests/ -v` — 63 tests pass
- [x] CLI diff output verified with sample messages
- [x] Web viewer Compare tab tested via Playwright: summary bar, diff table, detail panel with component breakdown, character-level highlighting, Reset button
- [ ] Manual browser testing for UX validation before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)